### PR TITLE
謎解き部屋を改良

### DIFF
--- a/src/app/mystery/clean/[slug]/cleanRoomItems.tsx
+++ b/src/app/mystery/clean/[slug]/cleanRoomItems.tsx
@@ -1,0 +1,336 @@
+// アイテム型定義
+type Item = {
+  id: number;
+  name: string;
+  imagePath?: string;
+  positionClasses?: string;
+  width?: string; // 例: "w-32"
+  height?: string; // 例: "h-32"
+  additionalStyles?: React.CSSProperties;
+  messages: {
+    text: string;
+    choices: {
+      confirmText: string;
+      cancelText: string;
+    }| null;
+  }[];
+};
+
+export const GetCleanItem = () => {
+
+  // 配列にて、アイテム、メッセージ、選択肢等をオブジェクトの形で管理。
+  const cleanRoomItems: Item[] = [
+    {
+      id: 1,
+      name: '日記',
+      positionClasses: "absolute top-3/4 left-3/4 translate-x-[calc(-50%-40px)] translate-y-[calc(-50%+100px)] opacity-0",
+      width: "w-32",
+      height: "h-16",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "誰かの日記が落ちている。読みますか？",
+          choices: {
+            confirmText: "読む",
+            cancelText: "読まない"
+          }
+        },
+        {
+          text: "日記がちょっと傷ついた。",
+          choices: null
+        },
+      ]
+    },
+    {
+      id: 2,
+      name: '赤い箱',
+      imagePath: '/box_red.png',
+      positionClasses: "absolute top-2/3 left-1/4 translate-x-[calc(-50%+110px)] translate-y-[calc(-50%+30px)] opacity-0",
+      width: "w-12",
+      height: "h-20",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "棚にボロボロの鍵がかかっている...衝撃を加えれば壊れそうだ。",
+          choices: null
+        },
+        {
+          text: "鍵が壊れている...開けますか？",
+          choices: {
+            confirmText: "開ける",
+            cancelText: "開けない"
+          }
+        },
+        {
+          text: "赤い箱を手に入れた",
+          choices: null
+        },
+        {
+          text: "引き出しの中は空っぽだ。",
+          choices: null
+        },
+        {
+          text: "ボロボロの鍵は砕け散った。",
+          choices: null
+        },
+        {
+          text: "鍵はすでに壊れている。",
+          choices: null
+        },
+        {
+          text: "どこかでカギの開く音がした...",
+          choices: null
+        },
+      ]
+    },
+    {
+      id: 3,
+      name: 'ドア',
+      positionClasses: "absolute top-1/2 left-1/3 translate-x-[calc(-50%-130px)] translate-y-[calc(-50%+60px)] w-30 h-96 opacity-0 text-white",
+      width: "w-24",
+      height: "h-12",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "ドアは不思議な力で固く閉ざされている。",
+          choices: null
+        },
+        {
+          text: "ドアが開いているが、もう一人を置いていくわけにはいかない...",
+          choices: null
+        },
+        {
+          text: "ドアが開いている。ここから抜け出せそうだ",
+          choices: {
+            confirmText: "出る",
+            cancelText: "やめておく"
+          }
+        },
+        {
+          text: "弾は虚しく弾かれた。",
+          choices: null
+        },
+        {
+          text: "鍵穴が完全に破壊されている。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 4,
+      name: 'パスワード付きの箱',
+      imagePath: '/passwordbox.png',
+      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%-35px)] translate-y-[calc(-50%+195px)] opacity-0",
+      width: "w-32",
+      height: "h-16",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "大きな箱だ。パスワードがかけられている。",
+          choices: {
+            confirmText: "見てみる",
+            cancelText: "やめておく"
+          }
+        },
+        {
+          text: "大きな箱だ。すでに開いている。",
+          choices: null
+        },
+        {
+          text: "キィンという音がした。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 5,
+      name: '銃',
+      positionClasses: "invisible",
+      messages: [
+        {
+          text: "箱が開いた。銃を手に入れた。",
+          choices: null
+        },
+        {
+          text: "壁の穴に銃口を当てた。向こうの部屋の様子がうっすらと見える。",
+          choices: null
+        },
+        {
+          text: "壁の穴に銃口を当てた。何かが邪魔で向こうの部屋がよく見えない。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 6,
+      name: 'はさみ',
+      positionClasses: "absolute top-1/2 left-2/3 translate-x-[calc(-50%-25px)] translate-y-[calc(-50%+160px)] opacity-0",
+      width: "w-36",
+      height: "h-16",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "ベッドの上にはさみがある。拾いますか？",
+          choices: {
+            confirmText: "拾う",
+            cancelText: "拾わない"
+          }
+        },
+        {
+          text: "はさみを手に入れた",
+          choices: null
+        },
+        {
+          text: "ベッドの上には何もない",
+          choices: null
+        },
+        {
+          text: "はさみを受け取った",
+          choices: null
+        },
+        {
+          text: "はさみを渡した",
+          choices: null
+        },
+        {
+          text: "ボスっという音がした。",
+          choices: null
+        },
+      ]
+    },
+    {
+      id: 7,
+      name: '青いカギ',
+      positionClasses: "invisible",
+      // コメントアウトで、クリック部分の色を消す
+      messages: [
+        {
+          text: "青いカギを受け取った",
+          choices: null,
+        },
+        {
+          text: "青いカギを渡した",
+          choices: null,
+        },
+      ]
+    },
+    {
+      id: 8,
+      name: '赤いカギ',
+      positionClasses: "invisible",
+      // コメントアウトで、クリック部分の色を消す
+      messages: [
+        {
+          text: "赤いカギを受け取った",
+          choices: null,
+        },
+        {
+          text: "赤いカギを渡した",
+          choices: null,
+        },
+      ]
+    },
+    {
+      id: 9,
+      name: '窓',
+      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%-40px)] translate-y-[calc(-50%-40px)] opacity-0 text-white",
+      width: "w-36",
+      height: "h-72",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "窓だ。月明かりに見惚れてしまう",
+          choices: null
+        },
+        {
+          text: "割れない。なんて頑丈な窓なんだ。",
+          choices: null
+        },
+      ]
+    },
+    {
+      id: 10,
+      name: '絵画',
+      positionClasses: "absolute top-1/2 left-3/4 translate-x-[calc(-50%-20px)] translate-y-[calc(-50%-80px)] -skew-y-12 opacity-0",
+      width: "w-36",
+      height: "h-36",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "大きな絵が飾られている。立派だ。",
+          choices: null
+        },
+        {
+          text: "絵を撃ってみた。罰当たりな気分になった。",
+          choices: null
+        },
+      ]
+    },
+    {
+      id: 11,
+      name: '本',
+      positionClasses: "absolute top-3/4 left-1/3 translate-x-[calc(-50%+50px)] translate-y-[calc(-50%+80px)] opacity-0",
+      width: "w-16",
+      height: "h-12",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "本に何か書かれている。【3XXX】",
+          choices: null
+        },
+        {
+          text: "本がちょっと傷ついた。",
+          choices: null
+        },
+      ]
+    },
+    {
+      id: 12,
+      name: '左カーテン',
+      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%-160px)] translate-y-[calc(-50%-100px)] opacity-0",
+      width: "w-24",
+      height: "h-64",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "重厚なカーテンだ。とても重そう。",
+          choices: null
+        },
+        {
+          text: "カーテンを撃った。弾は優しく包まれた",
+          choices: null
+        },
+      ]
+    },
+    {
+      id: 13,
+      name: '右カーテン',
+      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%+70px)] translate-y-[calc(-50%-100px)] opacity-0",
+      width: "w-24",
+      height: "h-64",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "重厚なカーテンだ。とても重そう。",
+          choices: null
+        },
+        {
+          text: "カーテンを撃った。弾は優しく包まれた",
+          choices: null
+        },
+      ]
+    },
+  ];
+
+  return cleanRoomItems;
+};

--- a/src/app/mystery/clean/[slug]/dirtyRoomItems.tsx
+++ b/src/app/mystery/clean/[slug]/dirtyRoomItems.tsx
@@ -1,0 +1,145 @@
+// アイテム型定義
+type Item = {
+  id: number;
+  name: string;
+  imagePath?: string;
+  positionClasses?: string;
+  width?: string; // 例: "w-32"
+  height?: string; // 例: "h-32"
+  additionalStyles?: React.CSSProperties;
+  messages: {
+    text: string;
+    choices: {
+      confirmText: string;
+      cancelText: string;
+    }| null;
+  }[];
+};
+
+export const GetDirtyItem = () => {
+
+  // 配列にて、アイテム、メッセージ、選択肢等をオブジェクトの形で管理。
+  const dirtyRoomItems: Item[] = [
+    {
+      id: 1,
+      name: '青い箱',
+      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%+90px)] translate-y-[calc(-50%+130px)] opacity-0",
+      width: "w-36",
+      height: "h-16",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "何かが砕け散る音がした。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 2,
+      name: 'ドア',
+      positionClasses: "absolute top-1/2 left-2/3 translate-x-[calc(-50%+120px)] translate-y-[calc(-50%)] w-36 h-96 opacity-0 text-white",
+      width: "w-24",
+      height: "h-12",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "木製の何かに当たる音がした。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 3,
+      name: 'ベッド',
+      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%-150px)] translate-y-[calc(-50%+100px)] -skew-y-12 opacity-0",
+      width: "w-64",
+      height: "h-24",
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "柔らかい何かに当たる音がした。",
+          choices: null
+        },
+      ]
+    },
+    {
+      id: 4,
+      name: '枕',
+      positionClasses: `absolute top-1/2 left-1/2 translate-x-[calc(-50%-80px)] translate-y-[calc(-50%+80px)] opacity-0`,
+      width: "w-36",
+      height: "h-12",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "ボスっという音がした",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 5,
+      name: '窓',
+      positionClasses: `absolute top-1/3 left-1/4 translate-x-[calc(-50%+90px)] translate-y-[calc(-50%+30px)] opacity-0`,
+      width: "w-36",
+      height: "h-64",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "硬いものに当たる音がした。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 6,
+      name: '椅子',
+      positionClasses: `absolute top-2/3 left-1/4 translate-x-[calc(-50%-90px)] translate-y-[calc(-50%+60px)] opacity-0`,
+      width: "w-48",
+      height: "h-24",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "木製の何かに当たった。落ち着かない。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 7,
+      name: '時計',
+      positionClasses: `absolute top-1/4 left-1/4 translate-x-[calc(-50%-100px)] translate-y-[calc(-50%+40px)] opacity-0`,
+      width: "w-28",
+      height: "h-36",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "何かに当たった。時が止まった気がした。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 8,
+      name: '絵画',
+      positionClasses: `absolute top-1/3 left-1/2 translate-x-[calc(-50%+115px)] translate-y-[calc(-50%-35px)] opacity-0`,
+      width: "w-36",
+      height: "h-36",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "何か変なものに当たった気がする。",
+          choices: null
+        }
+      ]
+    },
+  ];
+
+  return dirtyRoomItems;
+}

--- a/src/app/mystery/clean/[slug]/page.tsx
+++ b/src/app/mystery/clean/[slug]/page.tsx
@@ -2,6 +2,8 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from "next/image";
+import { GetCleanItem } from "./cleanRoomItems";
+import { GetDirtyItem } from "./dirtyRoomItems";
 
 // アイテム型定義
 type Item = {
@@ -93,6 +95,8 @@ const TriangleButton = ({ direction, handleClickTriangle }: any) => {
   };
 
 export default function Home({ params }: { params: { slug: string } }) {
+  const items: Item[] = GetCleanItem();
+  const dirtyRoomItems: Item[] = GetDirtyItem();
   const [ws, setWs] = useState<WebSocket | null>(null);
   const router = useRouter();
   const [isCleanDoorOpen, setIsCleanDoorOpen] = useState(false);
@@ -139,7 +143,7 @@ export default function Home({ params }: { params: { slug: string } }) {
     '4月11日',
     '夫との関係は悪化の一途を辿り、ついに私たちは離婚訴訟に至った。',
     '私は裁判で勝つためには、質素な生活を送らなければならないとアドバイスされた。これが私と子供たちにとって最善の策だと信じている。',
-    
+
     '4月30日',
     '娘の体重が増えると、療育費が減ると聞いた。だから、彼女には厳しい食事制限を課している。',
     '部屋に閉じ込めて、食事を減らしているのは彼女のためだと信じている。',
@@ -153,403 +157,6 @@ export default function Home({ params }: { params: { slug: string } }) {
     setDiaryCurrentTextIndex((prevIndex) => prevIndex + 1);
   };
 
-  // 配列にて、アイテム、メッセージ、選択肢等をオブジェクトの形で管理。
-  const items: Item[] = [
-    {
-      id: 1,
-      name: '日記',
-      positionClasses: "absolute top-3/4 left-3/4 translate-x-[calc(-50%-40px)] translate-y-[calc(-50%+100px)] opacity-0",
-      width: "w-32",
-      height: "h-16",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "誰かの日記が落ちている。読みますか？",
-          choices: {
-            confirmText: "読む",
-            cancelText: "読まない"
-          }
-        },
-      ]
-    },
-    {
-      id: 2,
-      name: '赤い箱',
-      imagePath: '/box_red.png',
-      positionClasses: "absolute top-2/3 left-1/4 translate-x-[calc(-50%+110px)] translate-y-[calc(-50%+30px)] opacity-0",
-      width: "w-12",
-      height: "h-20",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "棚にボロボロの鍵がかかっている...衝撃を加えれば壊れそうだ。",
-          choices: null
-        },
-        {
-          text: "鍵が壊れている...開けますか？",
-          choices: {
-            confirmText: "開ける",
-            cancelText: "開けない"
-          }
-        },
-        {
-          text: "赤い箱を手に入れた",
-          choices: null
-        },
-        {
-          text: "引き出しの中は空っぽだ。",
-          choices: null
-        },
-        {
-          text: "ボロボロの鍵は砕け散った。",
-          choices: null
-        },
-        {
-          text: "鍵はすでに壊れている。",
-          choices: null
-        },
-        {
-          text: "どこかでカギの開く音がした...",
-          choices: null
-        },
-      ]
-    },
-    {
-      id: 3,
-      name: 'ドア',
-      positionClasses: "absolute top-1/2 left-1/3 translate-x-[calc(-50%-130px)] translate-y-[calc(-50%+60px)] w-30 h-96 opacity-0 text-white",
-      width: "w-24",
-      height: "h-12",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "ドアは不思議な力で固く閉ざされている。",
-          choices: null
-        },
-        {
-          text: "ドアが開いているが、もう一人を置いていくわけにはいかない...",
-          choices: null
-        },
-        {
-          text: "ドアが開いている。ここから抜け出せそうだ",
-          choices: {
-            confirmText: "出る",
-            cancelText: "やめておく"
-          }
-        }
-      ]
-    },
-    {
-      id: 4,
-      name: 'パスワード付きの箱',
-      imagePath: '/passwordbox.png',
-      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%-35px)] translate-y-[calc(-50%+195px)] opacity-0",
-      width: "w-32",
-      height: "h-16",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "大きな箱だ。パスワードがかけられている。",
-          choices: {
-            confirmText: "見てみる",
-            cancelText: "やめておく"
-          }
-        },
-        {
-          text: "大きな箱だ。すでに開いている。",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 5,
-      name: '銃',
-      positionClasses: "invisible",
-      messages: [
-        {
-          text: "箱が開いた。銃を手に入れた",
-          choices: null
-        },
-        {
-          text: "壁の穴に銃口を当てた。向こうの部屋の様子がうっすらと見える。",
-          choices: null
-        },
-        {
-          text: "壁の穴に銃口を当てた。何かが邪魔で向こうの部屋がよく見えない。",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 6,
-      name: 'はさみ',
-      positionClasses: "absolute top-1/2 left-2/3 translate-x-[calc(-50%-25px)] translate-y-[calc(-50%+160px)] opacity-0",
-      width: "w-36",
-      height: "h-16",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "ベッドの上にはさみがある。拾いますか？",
-          choices: {
-            confirmText: "拾う",
-            cancelText: "拾わない"
-          }
-        },
-        {
-          text: "はさみを手に入れた",
-          choices: null
-        },
-        {
-          text: "ベッドの上には何もない",
-          choices: null
-        },
-        {
-          text: "はさみを受け取った",
-          choices: null
-        },
-        {
-          text: "はさみを渡した",
-          choices: null
-        },
-      ]
-    },
-    {
-      id: 7,
-      name: '青いカギ',
-      positionClasses: "invisible",
-      // コメントアウトで、クリック部分の色を消す
-      messages: [
-        {
-          text: "青いカギを受け取った",
-          choices: null,
-        },
-        {
-          text: "青いカギを渡した",
-          choices: null,
-        },
-      ]
-    },
-    {
-      id: 8,
-      name: '赤いカギ',
-      positionClasses: "invisible",
-      // コメントアウトで、クリック部分の色を消す
-      messages: [
-        {
-          text: "赤いカギを受け取った",
-          choices: null,
-        },
-        {
-          text: "赤いカギを渡した",
-          choices: null,
-        },
-      ]
-    },
-    {
-      id: 9,
-      name: '窓',
-      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%-40px)] translate-y-[calc(-50%-40px)] opacity-0 text-white",
-      width: "w-36",
-      height: "h-72",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "窓だ。月明かりに見惚れてしまう",
-          choices: null
-        },
-      ]
-    },
-    {
-      id: 10,
-      name: '絵画',
-      positionClasses: "absolute top-1/2 left-3/4 translate-x-[calc(-50%-20px)] translate-y-[calc(-50%-80px)] -skew-y-12 opacity-0",
-      width: "w-36",
-      height: "h-36",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "大きな絵が飾られている。立派だ。",
-          choices: null
-        },
-      ]
-    },
-    {
-      id: 11,
-      name: '本',
-      positionClasses: "absolute top-3/4 left-1/3 translate-x-[calc(-50%+50px)] translate-y-[calc(-50%+80px)] opacity-0",
-      width: "w-16",
-      height: "h-12",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "本に何か書かれている。【3XXX】",
-          choices: null
-        },
-      ]
-    },
-    {
-      id: 12,
-      name: '左カーテン',
-      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%-160px)] translate-y-[calc(-50%-100px)] opacity-0",
-      width: "w-24",
-      height: "h-64",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "重厚なカーテンだ。とても重そう。",
-          choices: null
-        },
-      ]
-    },
-    {
-      id: 13,
-      name: '右カーテン',
-      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%+70px)] translate-y-[calc(-50%-100px)] opacity-0",
-      width: "w-24",
-      height: "h-64",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "重厚なカーテンだ。とても重そう。",
-          choices: null
-        },
-      ]
-    },
-  ];
-  
-  // 配列にて、アイテム、メッセージ、選択肢等をオブジェクトの形で管理。
-  const dirtyRoomItems: Item[] = [
-    {
-      id: 1,
-      name: '青い箱',
-      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%+90px)] translate-y-[calc(-50%+130px)] opacity-0",
-      width: "w-36",
-      height: "h-16",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "何かが砕け散る音がした。",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 2,
-      name: 'ドア',
-      positionClasses: "absolute top-1/2 left-2/3 translate-x-[calc(-50%+120px)] translate-y-[calc(-50%)] w-36 h-96 opacity-0 text-white",
-      width: "w-24",
-      height: "h-12",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "木製の何かに当たる音がした。",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 3,
-      name: 'ベッド',
-      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%-150px)] translate-y-[calc(-50%+100px)] -skew-y-12 opacity-0",
-      width: "w-64",
-      height: "h-24",
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "柔らかい何かに当たる音がした。",
-          choices: null
-        },
-      ]
-    },
-    {
-      id: 4,
-      name: '枕',
-      positionClasses: `absolute top-1/2 left-1/2 translate-x-[calc(-50%-80px)] translate-y-[calc(-50%+80px)] opacity-0`,
-      width: "w-36",
-      height: "h-12",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "ボスっという音がした",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 5,
-      name: '窓',
-      positionClasses: `absolute top-1/3 left-1/4 translate-x-[calc(-50%+90px)] translate-y-[calc(-50%+30px)] opacity-0`,
-      width: "w-36",
-      height: "h-64",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "ガラスの割れる音がした",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 6,
-      name: '椅子',
-      positionClasses: `absolute top-2/3 left-1/4 translate-x-[calc(-50%-90px)] translate-y-[calc(-50%+60px)] opacity-0`,
-      width: "w-48",
-      height: "h-24",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "木製の何かに当たった。落ち着かない。",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 7,
-      name: '時計',
-      positionClasses: `absolute top-1/4 left-1/4 translate-x-[calc(-50%-100px)] translate-y-[calc(-50%+40px)] opacity-0`,
-      width: "w-28",
-      height: "h-36",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "何かに当たった。時が止まった気がした。",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 8,
-      name: '絵画',
-      positionClasses: `absolute top-1/3 left-1/2 translate-x-[calc(-50%+115px)] translate-y-[calc(-50%-35px)] opacity-0`,
-      width: "w-36",
-      height: "h-36",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "何か変なものに当たった気がする。",
-          choices: null
-        }
-      ]
-    },
-  ];
-
   let message: string | undefined;
   let choicesOptions: { confirmText: string; cancelText: string } | null = null;
 
@@ -561,47 +168,79 @@ export default function Home({ params }: { params: { slug: string } }) {
 
   // アイテムがクリックされた時の処理
   const handleClick = (item: Item) => {
-    setCurrentItem(item);
-    if (item.name === '赤い箱' && !isRedBoxBroken && !selectedItem) {
-      setMessageIndex(0);
-    } else if (item.name === '赤い箱' && isRedBoxBroken && !selectedItem && !acquiredRedBox) {
-      setMessageIndex(1);
-    } else if (item.name === '赤い箱' && isRedBoxBroken && !selectedItem && acquiredRedBox) {
-      setMessageIndex(3);
-    } else if (item.name === '赤い箱' && !isRedBoxBroken && selectedItem && selectedItem.name === "銃") {
-      setIsRedBoxBroken(true);
-      setMessageIndex(4);
-    } else if (item.name === '赤い箱' && isRedBoxBroken && selectedItem && selectedItem.name === "銃") {
-      setMessageIndex(5);
-    } else if (item.name === 'パスワード付きの箱' && !isPasswordBoxOpen) {
-      setMessageIndex(0);
-    } else if (item.name === 'パスワード付きの箱' && isPasswordBoxOpen) {
-      setMessageIndex(1);
-    } else if (item.name === 'ドア' && !isCleanDoorOpen && !isDirtyDoorOpen) {
-      setMessageIndex(0);
-    } else if (item.name === 'ドア' && isCleanDoorOpen && !isDirtyDoorOpen) {
-      setMessageIndex(1);
-    } else if (item.name === 'ドア' && isCleanDoorOpen && isDirtyDoorOpen) {
-      setMessageIndex(2);
-    } else if (item.name === 'はさみ' && !acquiredScissors) {
-      setMessageIndex(0);
-    } else if (item.name === 'はさみ' && acquiredScissors) {
-      setMessageIndex(2);
-    } else if (!acquiredItems.some(acquiredItem => acquiredItem.id === item.id)) {
-      setMessageIndex(0);
+    if (diaryCurrentTextIndex >= diaryTexts.length && currentTextIndex >= storyTexts.length && !putImageItem) {
+      setCurrentItem(item);
+      if (selectedItem && selectedItem.name === "銃") {
+        if (item.name === '赤い箱' && !isRedBoxBroken) {
+          setIsRedBoxBroken(true);
+          setMessageIndex(4);
+        } else if (item.name === '赤い箱' && isRedBoxBroken) {
+          setMessageIndex(5);
+        } else if (item.name === '日記') {
+          setMessageIndex(1);
+        } else if (item.name === 'ドア') {
+          setMessageIndex(3);
+        } else if (item.name === 'パスワード付きの箱') {
+          setMessageIndex(2);
+        } else if (item.name === 'はさみ') {
+          setMessageIndex(5);
+        } else if (item.name === '窓' || item.name === '絵画' || item.name === '本' || item.name === '左カーテン' || item.name === '右カーテン') {
+          setMessageIndex(1);
+        }
+      } else if ((selectedItem && selectedItem.name === "青いカギ") || (selectedItem && selectedItem.name === "赤いカギ")){
+        if (item.name === '赤い箱' && !isRedBoxBroken) {
+          setMessageIndex(0);
+        } else if (item.name === '赤い箱' && isRedBoxBroken && !acquiredRedBox) {
+          setMessageIndex(1);
+        } else if (item.name === '赤い箱' && isRedBoxBroken && acquiredRedBox) {
+          setMessageIndex(3);
+        } else if (item.name === 'パスワード付きの箱' && !isPasswordBoxOpen) {
+          setMessageIndex(0);
+        } else if (item.name === 'パスワード付きの箱' && isPasswordBoxOpen) {
+          setMessageIndex(1);
+        } else if (item.name === 'ドア') {
+          setMessageIndex(4);
+        } else if (item.name === 'はさみ') {
+          setMessageIndex(2);
+        } else if (!acquiredItems.some(acquiredItem => acquiredItem.id === item.id)) {
+          setMessageIndex(0);
+        }
+      } else {
+        if (item.name === '赤い箱' && !isRedBoxBroken) {
+          setMessageIndex(0);
+        } else if (item.name === '赤い箱' && isRedBoxBroken && !acquiredRedBox) {
+          setMessageIndex(1);
+        } else if (item.name === '赤い箱' && isRedBoxBroken && acquiredRedBox) {
+          setMessageIndex(3);
+        } else if (item.name === 'パスワード付きの箱' && !isPasswordBoxOpen) {
+          setMessageIndex(0);
+        } else if (item.name === 'パスワード付きの箱' && isPasswordBoxOpen) {
+          setMessageIndex(1);
+        } else if (item.name === 'ドア' && !isCleanDoorOpen && !isDirtyDoorOpen) {
+          setMessageIndex(0);
+        } else if (item.name === 'ドア' && isCleanDoorOpen && !isDirtyDoorOpen) {
+          setMessageIndex(1);
+        } else if (item.name === 'ドア' && isCleanDoorOpen && isDirtyDoorOpen) {
+          setMessageIndex(2);
+        } else if (item.name === 'はさみ' && !acquiredScissors) {
+          setMessageIndex(0);
+        } else if (item.name === 'はさみ' && acquiredScissors) {
+          setMessageIndex(2);
+        } else if (!acquiredItems.some(acquiredItem => acquiredItem.id === item.id)) {
+          setMessageIndex(0);
+        }
+      }
     }
   };
 
   // 銃でアイテムを撃った時の処理
   const handleShootItem = (dirtyRoomItem: Item) => {
     setCurrentItem(dirtyRoomItem);
+    setMessageIndex(0);
     if (dirtyRoomItem.name === '青い箱' && !isBlueBoxBroken) {
-      setMessageIndex(0);
       if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send('breakBlueBox');
       }
-    } else if (!acquiredItems.some(acquiredItem => acquiredItem.id === dirtyRoomItem.id)) {
-      setMessageIndex(0);
     }
   };
 
@@ -694,8 +333,9 @@ export default function Home({ params }: { params: { slug: string } }) {
     } else if (!dirtyIsReadyToAcceptItem && backgroundImage === '/black_background.png') {
       setBackgroundImage('/dark.png');
     }
-  }, [dirtyIsReadyToAcceptItem]);
+  }, [dirtyIsReadyToAcceptItem, backgroundImage]);
 
+  //アイテムの受け渡しや、銃口を穴に向ける
   const handleClickHole = () => {
     if (ws && ws.readyState === WebSocket.OPEN) {
       if (selectedItem && selectedItem.name === '銃' && !dirtyIsReadyToAcceptItem) {
@@ -899,7 +539,7 @@ export default function Home({ params }: { params: { slug: string } }) {
             width: `1300px`,
             height: `700px`
           }}
-          onClick={() => `${selectedItem && selectedItem.name === "銃" && backgroundImage !== '/wall.png' ? playGunSound() : undefined}`}
+          onClick={() => `${selectedItem && selectedItem.name === "銃" && backgroundImage !== '/wall.png' && diaryCurrentTextIndex >= diaryTexts.length ? playGunSound() : undefined}`}
         >
           {/* 条件に基づいて左の三角形ボタンを表示 */}
           {backgroundImage === '/clean_room.png' && (
@@ -1095,16 +735,12 @@ export default function Home({ params }: { params: { slug: string } }) {
             </>
           )}
           {/* 取得済みアイテム */}
-          <div className="absolute top-0 right-0 text-white">
+          <div className="absolute top-0 right-8 text-white">
             <div className="bg-gray-800 bg-opacity-60 p-2 rounded-t-lg cursor-pointer hover:bg-opacity-70" onClick={() => setIsItemListVisible(!isItemListVisible)}>
               <span>
                 アイテム一覧
-                <span className="ml-2">
-                  {isItemListVisible ? '▲' : '▼'}
-                </span>
               </span>
             </div>
-            {isItemListVisible && (
               <div className="bg-gray bg-opacity-60 p-2 rounded-b-lg shadow-xl border-t border-gray-500">
                 {acquiredItems.map(item => (
                   <div key={item.id}
@@ -1115,7 +751,6 @@ export default function Home({ params }: { params: { slug: string } }) {
                   </div>
                 ))}
               </div>
-            )}
           </div>
           {/* アイテムリストから選んだアイテムが画像を表示するもの（ぬいぐるみ、箱）の場合、画像を表示する */}
           {putImageItem && putImageItem.imagePath && (

--- a/src/app/mystery/dirty/[slug]/dirtyRoomItems.tsx
+++ b/src/app/mystery/dirty/[slug]/dirtyRoomItems.tsx
@@ -1,0 +1,299 @@
+// アイテム型定義
+type Item = {
+  id: number;
+  name: string;
+  imagePath?: string;
+  positionClasses: string;
+  width?: string; // 例: "w-32"
+  height?: string; // 例: "h-32"
+  additionalStyles?: React.CSSProperties;
+  messages: {
+    text: string;
+    choices: {
+      confirmText: string;
+      cancelText: string;
+    }| null;
+  }[];
+};
+
+export const GetDirtyItem = () => {
+  // 配列にて、アイテム、メッセージ、選択肢等をオブジェクトの形で管理。
+  const items: Item[] = [
+    {
+      id: 1,
+      name: '日記',
+      positionClasses: "absolute top-2/3 left-1/3 translate-x-[calc(-50%)] translate-y-[calc(-50%)] opacity-0",
+      width: "w-36",
+      height: "h-16",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "ベッドの上に誰かの日記がある。読みますか？",
+          choices: {
+            confirmText: "読む",
+            cancelText: "読まない"
+          }
+        },
+      ]
+    },
+    {
+      id: 2,
+      name: '青い箱',
+      imagePath: '/box_blue.png',
+      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%+90px)] translate-y-[calc(-50%+130px)] opacity-0",
+      width: "w-20",
+      height: "h-12",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "ボロボロの鍵がかかっている...衝撃を加えれば壊れそうだ。",
+          choices: null
+        },
+        {
+          text: "鍵が壊れている...開けますか？",
+          choices: {
+            confirmText: "開ける",
+            cancelText: "開けない"
+          }
+        },
+        {
+          text: "青い箱を手に入れた",
+          choices: null
+        },
+        {
+          text: "引き出しの中は空っぽだ。",
+          choices: null
+        },
+        {
+          text: "何かが砕け散る音がした。",
+          choices: null
+        },
+        {
+          text: "どこかでカギの開く音がした...",
+          choices: null
+        },
+      ]
+    },
+    {
+      id: 3,
+      name: 'ドア',
+      positionClasses: "absolute top-1/2 left-2/3 translate-x-[calc(-50%+120px)] translate-y-[calc(-50%)] w-36 h-96 opacity-0 text-white",
+      width: "w-24",
+      height: "h-12",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "ドアは不思議な力で固く閉ざされている",
+          choices: null
+        },
+        {
+          text: "ドアが開いているが、もう一人を置いていくわけにはいかない...",
+          choices: null
+        },
+        {
+          text: "ドアが開いている。ここから抜け出せそうだ",
+          choices: {
+            confirmText: "出る",
+            cancelText: "やめておく"
+          }
+        },
+        {
+          text: "鍵穴が完全に破壊されている。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 4,
+      name: 'オルゴール',
+      positionClasses: `absolute top-1/2 left-1/2 translate-x-[calc(-50%+90px)] translate-y-[calc(-50%+30px)] opacity-0`,
+      width: "w-24",
+      height: "h-12",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "引き出しを開けた。オルゴールがある。鳴らしてみますか？",
+          choices: {
+            confirmText: "鳴らす",
+            cancelText: "やめておく"
+          }
+        }
+      ]
+    },
+    {
+      id: 5,
+      name: 'ぬいぐるみ',
+      imagePath: '/stuffed_bear.png',
+      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%-150px)] translate-y-[calc(-50%+200px)] -skew-y-12 opacity-0",
+      width: "w-64",
+      height: "h-12",
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "ベッドの下に何かある...手を伸ばして取りますか？",
+          choices: {
+            confirmText: "手を伸ばす",
+            cancelText: "やめておく"
+          }
+        },
+        {
+          text: "ぬいぐるみを手に入れた",
+          choices: null
+        },
+        {
+          text: "ベッドの下にはもう何もない",
+          choices: null
+        },
+        {
+          text: "ぬいぐるみをハサミで切った。中からカギが2本出てきた",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 6,
+      name: 'はさみ',
+      positionClasses: "invisible",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "はさみを受け取った",
+          choices: null
+        },
+        {
+          text: "はさみを渡した",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 7,
+      name: '青いカギ',
+      positionClasses: "invisible",
+      // コメントアウトで、クリック部分の色を消す
+      messages: [
+        {
+          text: "青いカギを受け取った",
+          choices: null,
+        },
+        {
+          text: "青いカギを渡した",
+          choices: null,
+        },
+      ]
+    },
+    {
+      id: 8,
+      name: '赤いカギ',
+      positionClasses: "invisible",
+      // コメントアウトで、クリック部分の色を消す
+      messages: [
+        {
+          text: "赤いカギを受け取った",
+          choices: null,
+        },
+        {
+          text: "赤いカギを渡した",
+          choices: null,
+        },
+      ]
+    },
+    {
+      id: 9,
+      name: '窓',
+      positionClasses: `absolute top-1/3 left-1/4 translate-x-[calc(-50%+90px)] translate-y-[calc(-50%+30px)] opacity-0`,
+      width: "w-36",
+      height: "h-64",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "窓だ。月明かりに照らされている。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 10,
+      name: '絵画',
+      positionClasses: `absolute top-1/3 left-1/2 translate-x-[calc(-50%+115px)] translate-y-[calc(-50%-35px)] opacity-0`,
+      width: "w-36",
+      height: "h-36",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "変な絵だなぁ。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 11,
+      name: '蜘蛛の巣',
+      positionClasses: `absolute top-1/3 left-1/3 translate-x-[calc(-50%+115px)] translate-y-[calc(-50%-35px)] opacity-0`,
+      width: "w-36",
+      height: "h-48",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "蜘蛛の巣だ。ばっちぃ",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 12,
+      name: '枕',
+      positionClasses: `absolute top-1/2 left-1/2 translate-x-[calc(-50%-80px)] translate-y-[calc(-50%+80px)] opacity-0`,
+      width: "w-36",
+      height: "h-12",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "枕だ。硬さはあまり好みじゃない。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 13,
+      name: '椅子',
+      positionClasses: `absolute top-2/3 left-1/4 translate-x-[calc(-50%-90px)] translate-y-[calc(-50%+60px)] opacity-0`,
+      width: "w-48",
+      height: "h-24",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "椅子がある。一旦落ち着いてと。",
+          choices: null
+        }
+      ]
+    },
+    {
+      id: 14,
+      name: '時計',
+      positionClasses: `absolute top-1/4 left-1/4 translate-x-[calc(-50%-100px)] translate-y-[calc(-50%+40px)] opacity-0`,
+      width: "w-28",
+      height: "h-36",
+      // コメントアウトで、クリック部分の色を消す
+      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
+      messages: [
+        {
+          text: "時計がある。針は止まっているようだ。",
+          choices: null
+        }
+      ]
+    },
+  ];
+
+  return items;
+}

--- a/src/app/mystery/dirty/[slug]/page.tsx
+++ b/src/app/mystery/dirty/[slug]/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from "next/image";
+import { GetDirtyItem } from "./dirtyRoomItems";
 
 // アイテム型定義
 type Item = {
@@ -54,6 +55,7 @@ const TriangleButton = ({ direction, handleClickTriangle }: any) => {
 };
 
 export default function Home({ params }: { params: { slug: string } }) {
+  const items: Item[] = GetDirtyItem();
   const [ws, setWs] = useState<WebSocket | null>(null);
   const router = useRouter();
   const [isCleanDoorOpen, setIsCleanDoorOpen] = useState(false);
@@ -108,280 +110,6 @@ export default function Home({ params }: { params: { slug: string } }) {
     setDiaryCurrentTextIndex((prevIndex) => prevIndex + 1);
   };
 
-  // 配列にて、アイテム、メッセージ、選択肢等をオブジェクトの形で管理。
-  const items: Item[] = [
-    {
-      id: 1,
-      name: '日記',
-      positionClasses: "absolute top-2/3 left-1/3 translate-x-[calc(-50%)] translate-y-[calc(-50%)] opacity-0",
-      width: "w-36",
-      height: "h-16",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "ベッドの上に誰かの日記がある。読みますか？",
-          choices: {
-            confirmText: "読む",
-            cancelText: "読まない"
-          }
-        },
-      ]
-    },
-    {
-      id: 2,
-      name: '青い箱',
-      imagePath: '/box_blue.png',
-      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%+90px)] translate-y-[calc(-50%+130px)] opacity-0",
-      width: "w-20",
-      height: "h-12",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "ボロボロの鍵がかかっている...衝撃を加えれば壊れそうだ。",
-          choices: null
-        },
-        {
-          text: "鍵が壊れている...開けますか？",
-          choices: {
-            confirmText: "開ける",
-            cancelText: "開けない"
-          }
-        },
-        {
-          text: "青い箱を手に入れた",
-          choices: null
-        },
-        {
-          text: "引き出しの中は空っぽだ。",
-          choices: null
-        },
-        {
-          text: "何かが砕け散る音がした。",
-          choices: null
-        },
-        {
-          text: "どこかでカギの開く音がした...",
-          choices: null
-        },
-      ]
-    },
-    {
-      id: 3,
-      name: 'ドア',
-      positionClasses: "absolute top-1/2 left-2/3 translate-x-[calc(-50%+120px)] translate-y-[calc(-50%)] w-36 h-96 opacity-0 text-white",
-      width: "w-24",
-      height: "h-12",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "ドアは不思議な力で固く閉ざされている",
-          choices: null
-        },
-        {
-          text: "ドアが開いているが、もう一人を置いていくわけにはいかない...",
-          choices: null
-        },
-        {
-          text: "ドアが開いている。ここから抜け出せそうだ",
-          choices: {
-            confirmText: "出る",
-            cancelText: "やめておく"
-          }
-        }
-      ]
-    },
-    {
-      id: 4,
-      name: 'オルゴール',
-      positionClasses: `absolute top-1/2 left-1/2 translate-x-[calc(-50%+90px)] translate-y-[calc(-50%+30px)] opacity-0`,
-      width: "w-24",
-      height: "h-12",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "引き出しを開けた。オルゴールがある。鳴らしてみますか？",
-          choices: {
-            confirmText: "鳴らす",
-            cancelText: "やめておく"
-          }
-        }
-      ]
-    },
-    {
-      id: 5,
-      name: 'ぬいぐるみ',
-      imagePath: '/stuffed_bear.png',
-      positionClasses: "absolute top-1/2 left-1/2 translate-x-[calc(-50%-150px)] translate-y-[calc(-50%+200px)] -skew-y-12 opacity-0",
-      width: "w-64",
-      height: "h-12",
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "ベッドの下に何かある...手を伸ばして取りますか？",
-          choices: {
-            confirmText: "手を伸ばす",
-            cancelText: "やめておく"
-          }
-        },
-        {
-          text: "ぬいぐるみを手に入れた",
-          choices: null
-        },
-        {
-          text: "ベッドの下にはもう何もない",
-          choices: null
-        },
-        {
-          text: "ぬいぐるみをハサミで切った。中からカギが2本出てきた",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 6,
-      name: 'はさみ',
-      positionClasses: "invisible",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "はさみを受け取った",
-          choices: null
-        },
-        {
-          text: "はさみを渡した",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 7,
-      name: '青いカギ',
-      positionClasses: "invisible",
-      // コメントアウトで、クリック部分の色を消す
-      messages: [
-        {
-          text: "青いカギを受け取った",
-          choices: null,
-        },
-        {
-          text: "青いカギを渡した",
-          choices: null,
-        },
-      ]
-    },
-    {
-      id: 8,
-      name: '赤いカギ',
-      positionClasses: "invisible",
-      // コメントアウトで、クリック部分の色を消す
-      messages: [
-        {
-          text: "赤いカギを受け取った",
-          choices: null,
-        },
-        {
-          text: "赤いカギを渡した",
-          choices: null,
-        },
-      ]
-    },
-    {
-      id: 9,
-      name: '窓',
-      positionClasses: `absolute top-1/3 left-1/4 translate-x-[calc(-50%+90px)] translate-y-[calc(-50%+30px)] opacity-0`,
-      width: "w-36",
-      height: "h-64",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "窓だ。月明かりに照らされている。",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 10,
-      name: '絵画',
-      positionClasses: `absolute top-1/3 left-1/2 translate-x-[calc(-50%+115px)] translate-y-[calc(-50%-35px)] opacity-0`,
-      width: "w-36",
-      height: "h-36",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "変な絵だなぁ。",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 11,
-      name: '蜘蛛の巣',
-      positionClasses: `absolute top-1/3 left-1/3 translate-x-[calc(-50%+115px)] translate-y-[calc(-50%-35px)] opacity-0`,
-      width: "w-36",
-      height: "h-48",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "蜘蛛の巣だ。ばっちぃ",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 12,
-      name: '枕',
-      positionClasses: `absolute top-1/2 left-1/2 translate-x-[calc(-50%-80px)] translate-y-[calc(-50%+80px)] opacity-0`,
-      width: "w-36",
-      height: "h-12",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "枕だ。硬さはあまり好みじゃない。",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 13,
-      name: '椅子',
-      positionClasses: `absolute top-2/3 left-1/4 translate-x-[calc(-50%-90px)] translate-y-[calc(-50%+60px)] opacity-0`,
-      width: "w-48",
-      height: "h-24",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "椅子がある。一旦落ち着いてと。",
-          choices: null
-        }
-      ]
-    },
-    {
-      id: 14,
-      name: '時計',
-      positionClasses: `absolute top-1/4 left-1/4 translate-x-[calc(-50%-100px)] translate-y-[calc(-50%+40px)] opacity-0`,
-      width: "w-28",
-      height: "h-36",
-      // コメントアウトで、クリック部分の色を消す
-      additionalStyles: { background: 'rgba(255, 255, 255, 0.1)', borderRadius: '8px' },
-      messages: [
-        {
-          text: "時計がある。針は止まっているようだ。",
-          choices: null
-        }
-      ]
-    },
-  ];
-
   let message: string | undefined;
   let choicesOptions: { confirmText: string; cancelText: string } | null = null;
 
@@ -393,33 +121,45 @@ export default function Home({ params }: { params: { slug: string } }) {
 
   // アイテムがクリックされた時の処理
   const handleClick = (item: Item) => {
-    if (item.name === '青い箱' && !isBlueBoxBroken) {
+    if (diaryCurrentTextIndex >= diaryTexts.length && currentTextIndex >= storyTexts.length && !putImageItem) {
       setCurrentItem(item);
-      setMessageIndex(0);
-    } else if (item.name === '青い箱' && isBlueBoxBroken && !acquiredBlueBox) {
-      setCurrentItem(item);
-      setMessageIndex(1);
-    } else if (item.name === '青い箱' && isBlueBoxBroken && acquiredBlueBox ) {
-      setCurrentItem(item);
-      setMessageIndex(3);
-    } else if (item.name === 'ドア' && !isDirtyDoorOpen && !isCleanDoorOpen) {
-      setCurrentItem(item);
-      setMessageIndex(0);
-    } else if (item.name === 'ドア' && isDirtyDoorOpen && !isCleanDoorOpen) {
-      setCurrentItem(item);
-      setMessageIndex(1);
-    } else if (item.name === 'ドア' && isDirtyDoorOpen && isCleanDoorOpen) {
-      setCurrentItem(item);
-      setMessageIndex(2);
-    } else if (item.name === 'ぬいぐるみ' && !acquiredBear) {
-      setCurrentItem(item);
-      setMessageIndex(0);
-    } else if (item.name === 'ぬいぐるみ' && acquiredBear) {
-      setCurrentItem(item);
-      setMessageIndex(2);
-    } else if (!acquiredItems.some(acquiredItem => acquiredItem.id === item.id)) {
-      setCurrentItem(item);
-      setMessageIndex(0); 
+      if ((selectedItem && selectedItem.name === "青いカギ") || (selectedItem && selectedItem.name === "赤いカギ")) {
+        if (item.name === '青い箱' && !isBlueBoxBroken) {
+          setMessageIndex(0);
+        } else if (item.name === '青い箱' && isBlueBoxBroken && !acquiredBlueBox) {
+          setMessageIndex(1);
+        } else if (item.name === '青い箱' && isBlueBoxBroken && acquiredBlueBox ) {
+          setMessageIndex(3);
+        } else if (item.name === 'ドア') {
+          setMessageIndex(3);
+        } else if (item.name === 'ぬいぐるみ' && !acquiredBear) {
+          setMessageIndex(0);
+        } else if (item.name === 'ぬいぐるみ' && acquiredBear) {
+          setMessageIndex(2);
+        } else if (!acquiredItems.some(acquiredItem => acquiredItem.id === item.id)) {
+          setMessageIndex(0); 
+        }
+      } else {
+        if (item.name === '青い箱' && !isBlueBoxBroken) {
+          setMessageIndex(0);
+        } else if (item.name === '青い箱' && isBlueBoxBroken && !acquiredBlueBox) {
+          setMessageIndex(1);
+        } else if (item.name === '青い箱' && isBlueBoxBroken && acquiredBlueBox ) {
+          setMessageIndex(3);
+        } else if (item.name === 'ドア' && !isDirtyDoorOpen && !isCleanDoorOpen) {
+          setMessageIndex(0);
+        } else if (item.name === 'ドア' && isDirtyDoorOpen && !isCleanDoorOpen) {
+          setMessageIndex(1);
+        } else if (item.name === 'ドア' && isDirtyDoorOpen && isCleanDoorOpen) {
+          setMessageIndex(2);
+        } else if (item.name === 'ぬいぐるみ' && !acquiredBear) {
+          setMessageIndex(0);
+        } else if (item.name === 'ぬいぐるみ' && acquiredBear) {
+          setMessageIndex(2);
+        } else if (!acquiredItems.some(acquiredItem => acquiredItem.id === item.id)) {
+          setMessageIndex(0); 
+        }
+      }
     }
   };
 
@@ -576,7 +316,6 @@ export default function Home({ params }: { params: { slug: string } }) {
           } else if (event.data == "openDirtyDoor") {
             setIsDirtyDoorOpen(true);
           } else if (event.data == "breakBlueBox") {
-            //playGunSound();
             setCurrentItem(items[1]);
             setMessageIndex(4);
             setIsBlueBoxBroken(true);
@@ -612,6 +351,12 @@ export default function Home({ params }: { params: { slug: string } }) {
     const sound = new Audio("/se_gun_fire10.wav");
     sound.play();
   };
+
+  useEffect (() => {
+  if (isGameOver) {
+    playGunSound();
+  }
+  },[isGameOver]);
 
   const reStartGame = () => {
     setIsCleanDoorOpen(false);
@@ -721,16 +466,12 @@ export default function Home({ params }: { params: { slug: string } }) {
           )}
           
           {/* 取得済みアイテム */}
-          <div className="absolute top-0 right-0 text-white">
+          <div className="absolute top-0 right-8 text-white">
             <div className="bg-gray-800 bg-opacity-60 p-2 rounded-t-lg cursor-pointer hover:bg-opacity-70" onClick={() => setIsItemListVisible(!isItemListVisible)}>
               <span>
                 アイテム一覧
-                <span className="ml-2">
-                  {isItemListVisible ? '▲' : '▼'}
-                </span>
               </span>
             </div>
-            {isItemListVisible && (
             <div className="bg-gray bg-opacity-60 p-2 rounded-b-lg shadow-xl border-t border-gray-500">
               {acquiredItems.map(item => (
                 <div key={item.id} 
@@ -741,7 +482,6 @@ export default function Home({ params }: { params: { slug: string } }) {
                 </div>
               ))}
             </div>
-            )}
           </div>
           {/* アイテムリストから選んだアイテムが画像を表示するもの（ぬいぐるみ、箱）の場合、画像を表示する */}
           {putImageItem && putImageItem.imagePath && (


### PR DESCRIPTION
アイテムのデータを別ファイルに分けた。
特定のアイテムを選択している状態で部屋のアイテムをクリックすると、意図しない挙動をするバグを修正。
銃を選択している状態でアイテムをクリックすると、今までとは違うメッセージが出るようにした。